### PR TITLE
Carry ?risk search param across links

### DIFF
--- a/apocrypha.bak.html
+++ b/apocrypha.bak.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/apocrypha.html
+++ b/apocrypha.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/bigbot.html
+++ b/bigbot.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <script>

--- a/bigbot_2.html
+++ b/bigbot_2.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <script>

--- a/catesby.html
+++ b/catesby.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <script>

--- a/dates.html
+++ b/dates.html
@@ -6,11 +6,17 @@
 <meta name="viewport" content="width=device-width">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <style>

--- a/emails.html
+++ b/emails.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <script>

--- a/erajbhandari_diagalpha.html
+++ b/erajbhandari_diagalpha.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/interface.html
+++ b/interface.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/muldrake.html
+++ b/muldrake.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/nogrub.html
+++ b/nogrub.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/parade.html
+++ b/parade.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/parade2.html
+++ b/parade2.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/quest_aon.html
+++ b/quest_aon.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/quest_pica.html
+++ b/quest_pica.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/quest_skimmerite.html
+++ b/quest_skimmerite.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/quest_suborbital_airlines.html
+++ b/quest_suborbital_airlines.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/quest_vacuum_rescue.html
+++ b/quest_vacuum_rescue.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/roborev_v2.html
+++ b/roborev_v2.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/scripts/colorfix.js
+++ b/scripts/colorfix.js
@@ -133,11 +133,17 @@ var HEAD=`<!DOCTYPE html>
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/teach_me.html
+++ b/teach_me.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>

--- a/trace.html
+++ b/trace.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <script>

--- a/tresham.html
+++ b/tresham.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 <script>

--- a/twitter.html
+++ b/twitter.html
@@ -5,11 +5,17 @@
 <link rel="stylesheet" href="./hackmud.css">
 <script>
 function fixRisk() {
-	if(document.location.search=='?risk')
+	if(document.location.search=='?risk'){
 		[...document.all].forEach(x=>{
 			if(x.style.color=='rgb(0, 0, 0)')
 				x.style.textShadow='0px 0px 5px white'
+		});
+
+		[...document.getElementsByTagName('a')].forEach(x=>{
+			if(x.href)
+				x.href+='?risk'
 		})
+	}
 }
 </script>
 </head>


### PR DESCRIPTION
This extends the `fixRisk()` function to append `?risk` to the href of all anchor elements present in the document, if `?risk` is currently present in the search params.